### PR TITLE
Changes to replace `itsdangerous` with `PyJWT` as a `flask-oidc` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask
-itsdangerous
+PyJWT
 oauth2client
 six


### PR DESCRIPTION
These changes are taken directly from `gerwout`'s fork of `flask-oidc` since they have not been merged to upstream and it seems the upstream library is not being currently actively maintained.