### PR TITLE
Allow providing access token when registering a new OIDC client

### DIFF
--- a/flask_oidc/registration.py
+++ b/flask_oidc/registration.py
@@ -89,7 +89,7 @@ class RegistrationError(Exception):
 
 
 # OpenID Connect Dynamic Client Registration 1.0
-def register_client(provider_info, redirect_uris):
+def register_client(provider_info, redirect_uris, access_token=None):
     """
     This function registers a new client with the specified OpenID Provider,
     and then returns the regitered client ID and other information.
@@ -100,6 +100,9 @@ def register_client(provider_info, redirect_uris):
     :param redirect_uris: The redirect URIs the application wants to
         register.
     :type redirect_uris: list
+    :param access_token: Bearer token to access the client registration API
+        of the OpenID Provider.
+    :type access_token: str, optional
     :returns: An object containing the information needed to configure the
         actual client code to communicate with the OpenID Provider.
     :rtype: dict
@@ -116,6 +119,8 @@ def register_client(provider_info, redirect_uris):
                    'token_endpoint_auth_method': 'client_secret_post'}
 
     headers = {'Content-type': 'application/json'}
+    if access_token:
+        headers['Authorization'] = 'Bearer {}'.format(access_token)
 
     resp, content = httplib2.Http().request(
         provider_info['registration_endpoint'], 'POST',

--- a/flask_oidc/registration_util.py
+++ b/flask_oidc/registration_util.py
@@ -44,6 +44,8 @@ def _parse_args():
                         help='Base URL to the application')
     parser.add_argument('--token-introspection-uri',
                         help='Token introspection URI')
+    parser.add_argument('--access-token',
+                        help='Initial access token or bearer token')
     parser.add_argument('--output-file', default='client_secrets.json',
                         help='File to write client info to')
     parser.add_argument('--debug', action='store_true')
@@ -71,8 +73,10 @@ def main():
         return 1
     if args.debug:
         print('Provider info: %s' % OP)
+    access_token = args.access_token or None
     try:
-        reg_info = registration.register_client(OP, redirect_uris)
+        reg_info = registration.register_client(OP, redirect_uris,
+                                                access_token=access_token)
     except Exception as ex:
         print('Error registering client')
         if args.debug:


### PR DESCRIPTION
The `oidc-register` CLI tool does not support providing an access token when registering an OIDC client.

For self-hosted OIDC provider servers eg. keycloak, we may not want to make the client registration API public and instead use a `Bearer Token` or `Initial Access Token` as indicated in the [docs](https://wjw465150.gitbooks.io/keycloak-documentation/content/securing_apps/topics/client-registration.html).

This PR modifies the code to make this possible by adding a CLI parameter `--access-token` to the `oidc-register` command.