### PR TITLE
Git submodule fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/pallets/flask-sphinx-themes.git
+	url = git@github.com:pallets/flask-sphinx-themes.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git
+	url = git://github.com/pallets/flask-sphinx-themes.git


### PR DESCRIPTION
The old repo `mitsuhiko/flask-sphinx-themes` was renamed to `pallets/flask-sphinx-themes` and now has actually been completely deprecated in favour of https://github.com/pallets/pallets-sphinx-themes which provides sphinx themes for other frameworks apart from flask.

This PR just fixes the URL to point to the now archived https://github.com/pallets/flask-sphinx-themes to ensure `setup.py` commands work.