### PR TITLE
Added setup_requires in setup.py for nosetests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'six',
     ],
     tests_require=['nose', 'mock'],
+    setup_requires=['nose', 'mock'],
     entry_points={
         'console_scripts': ['oidc-register=flask_oidc.registration_util:main'],
     },


### PR DESCRIPTION
This change allows running `python setup.py nosetests` directly without having to install nose first. Ref: https://nose.readthedocs.io/en/latest/api/commands.html